### PR TITLE
Fix typo in moves api call

### DIFF
--- a/zenhub/core.py
+++ b/zenhub/core.py
@@ -134,7 +134,7 @@ class Zenhub(object):
 
         See: https://github.com/ZenHubIO/API#move-an-issue-between-pipelines
         """
-        url = f"/p2/workspaces/{workspace_id}/repositories/{repo_id}/issues/{issue_number}/move"
+        url = f"/p2/workspaces/{workspace_id}/repositories/{repo_id}/issues/{issue_number}/moves"
         body = {"pipeline_id": pipeline_id, "position": position}
         return self._post(url, body)
 


### PR DESCRIPTION
The API endpoint for moving a repo is `moves` not `move`. The exiting code creates 404 trying to use this function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/pyzenhub/1)
<!-- Reviewable:end -->
